### PR TITLE
Fixed Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # callisto-core
 
-This is the report intake, escrow, matching and secure delivery code for [Callisto](www.projectcallisto.org), an online reporting system for sexual assault. 
+This is the report intake, escrow, matching and secure delivery code for [Callisto](https://www.projectcallisto.org), an online reporting system for sexual assault. 
 
 Learn more about how Callisto works:
 <a href="https://www.ted.com/talks/jessica_ladd_the_reporting_system_that_sexual_assault_survivors_want?language=en" target="_blank"><img src="https://www.projectcallisto.org/assets/img/ted-video-still.png" alt="Callisto TED talk"></a>
@@ -12,4 +12,4 @@ Learn more about information escrows:
 
 [Contribute](https://github.com/SexualHealthInnovations/callisto-core/blob/master/CONTRIBUTING.md) to callisto-core.
 
-Want to talk about extending the code to other applications, how Callisto works, or schedule a demo of Callisto for your campus? Contact us at tech@sexualhealthinnovations.org.
+Want to talk about extending the code to other applications, how Callisto works, or schedule a demo of Callisto for your campus? Contact us at [tech@sexualhealthinnovations.org](mailto:tech@sexualhealthinnovations.org).


### PR DESCRIPTION
The link within the README did not work (it was interpreted as a relative link). Also I added a `mailto` link to the mail at the bottom of the README.

Cheers