### PR TITLE
Python 2.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,14 @@ services:
     - postgresql
 env:
     - db_user=postgres
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=py35
 install:
     - pip install pyflakes tox
 script:
     - pyflakes setup.py runtests.py tests callisto
-    - tox -e py34-django18,py34-django19
+    - tox
 before_cache:
     - rm -r $TRAVIS_BUILD_DIR/.tox/log $TRAVIS_BUILD_DIR/.tox/dist $TRAVIS_BUILD_DIR/.tox/*/log $TRAVIS_BUILD_DIR/.tox/*/lib/python*/site-packages/callisto*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ cache:
 services:
     - postgresql
 env:
-    - TOXENV=py27 db_user=postgres
-    - TOXENV=py33 db_user=postgres
-    - TOXENV=py34 db_user=postgres
-    - TOXENV=py35 db_user=postgres
+    - TOXENV=django18 db_user=postgres
+    - TOXENV=django19 db_user=postgres
 install:
     - pip install pyflakes tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ cache:
 services:
     - postgresql
 env:
-    - db_user=postgres
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
+    - TOXENV=py27 db_user=postgres
+    - TOXENV=py33 db_user=postgres
+    - TOXENV=py34 db_user=postgres
+    - TOXENV=py35 db_user=postgres
 install:
     - pip install pyflakes tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
+    - "2.7"
+    - "3.3"
     - "3.4"
+    - "3.5"
 sudo: false
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ services:
 env:
     - TOXENV=django18 db_user=postgres
     - TOXENV=django19 db_user=postgres
+matrix:
+    exclude:
+        - python: "3.3"
+          env: TOXENV=django19 db_user=postgres
 install:
     - pip install pyflakes tox
 script:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Learn more about how Callisto works:
 Learn more about information escrows:
 <a href="https://www.youtube.com/watch?v=mYV6_OaZeEs" target="_blank"><img src="https://www.projectcallisto.org/assets/img/pwl-video-still.png" alt="information escrow talk at Papers We Love" width="640"></a>
 
+### Requirements
+`callisto-core` supports Django 1.8 and Django 1.9, running on Python 3.3, 3.4, or 3.5. Python 2.7 is provisionally supported, pending [further testing](https://githib.com/SexualHealthInnovations/callisto-core/issue/19).
+
 [Donate](https://www.sexualhealthinnovations.org/donate/) to Sexual Health Innovations, the organization behind Callisto.
 
 [Contribute](https://github.com/SexualHealthInnovations/callisto-core/blob/master/CONTRIBUTING.md) to callisto-core.

--- a/callisto/delivery/forms.py
+++ b/callisto/delivery/forms.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from django.forms.formsets import formset_factory
 from callisto.evaluation.models import EvalRow
 from nacl.exceptions import CryptoError
-from urllib.parse import urlsplit, parse_qs
+from six.moves.urllib.parse import urlsplit, parse_qs
 from zxcvbn import password_strength
 
 REQUIRED_ERROR = "The {0} field is required."

--- a/callisto/delivery/models.py
+++ b/callisto/delivery/models.py
@@ -6,6 +6,7 @@ from django.utils.html import strip_tags
 import nacl.secret
 import nacl.utils
 import hashlib
+import six
 from django.utils.crypto import pbkdf2, get_random_string
 from django.template import Template, Context
 from django.contrib.sites.models import Site
@@ -69,6 +70,7 @@ class Report(models.Model):
         else:
             return None
 
+@six.python_2_unicode_compatible
 class EmailNotification(models.Model):
     name = models.CharField(blank=False, max_length=50, primary_key=True)
     subject = models.CharField(blank=False, max_length=77)
@@ -95,6 +97,7 @@ class EmailNotification(models.Model):
         email.attach_alternative(self.render_body(context), "text/html")
         email.send()
 
+@six.python_2_unicode_compatible
 class MatchReport(models.Model):
     report = models.ForeignKey('Report')
     contact_phone = models.CharField(blank=False, max_length=256)

--- a/callisto/delivery/report_delivery.py
+++ b/callisto/delivery/report_delivery.py
@@ -46,7 +46,7 @@ class NumberedCanvas(canvas.Canvas):
         #self.setFont('OpenSans',12)
         self.drawRightString(width - margin, margin, "Page %d of %d" % (self._pageNumber, page_count))
 
-class PDFReport:
+class PDFReport(object):
 
     unselected = u'\u2610'
     selected = u'\u2717'
@@ -266,7 +266,7 @@ class PDFReport:
 class PDFFullReport(PDFReport):
 
     def __init__(self, report, decrypted_report):
-        super().__init__()
+        super(PDFFullReport, self).__init__()
         self.user = report.owner
         self.report = report
         self.decrypted_report = decrypted_report
@@ -363,7 +363,7 @@ class PDFMatchReport(PDFReport):
     report_title = "Match Report"
 
     def __init__(self, matches):
-        super().__init__()
+        super(PDFMatchReport, self).__init__()
         self.matches = matches
 
     def generate_match_report(self, report_id):

--- a/callisto/delivery/wizard.py
+++ b/callisto/delivery/wizard.py
@@ -21,7 +21,7 @@ class EncryptedFormBaseWizard(ConfigurableFormWizard):
             if cleaned_data:
                 key = cleaned_data.get('key')
                 self.form_to_edit = json.loads(self.object_to_edit.decrypted_report(key))
-        return super().get_form_initial(step)
+        return super(EncryptedFormBaseWizard, self).get_form_initial(step)
 
     @classmethod
     def get_key_form(cls, record_to_edit):

--- a/callisto/evaluation/admin.py
+++ b/callisto/evaluation/admin.py
@@ -9,7 +9,7 @@ class EvalFieldInline(admin.StackedInline):
 
 class WithEval(object):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(WithEval, self).__init__(*args, **kwargs)
         self.inlines = (self.inlines or []) + [EvalFieldInline,]
 
 class SingleLineTextWithEvalAdmin(WithEval, SingleLineTextAdmin):

--- a/callisto/evaluation/management/commands/decrypt_eval_data.py
+++ b/callisto/evaluation/management/commands/decrypt_eval_data.py
@@ -2,6 +2,7 @@ import json
 
 import environ
 import gnupg
+import six
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
@@ -25,7 +26,7 @@ class Command(BaseCommand):
                              'timestamp': row.timestamp.timestamp()}
             gpg = gnupg.GPG()
             gpg.import_keys(eval_key)
-            decrypted_eval_row = str(gpg.decrypt(row.row))
+            decrypted_eval_row = six.text_type(gpg.decrypt(six.binary_type(row.row)))
             if decrypted_eval_row:
                 decrypted_row.update(json.loads(decrypted_eval_row))
             decrypted_eval_data.append(decrypted_row)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ psycopg2==2.6.1
 pytz==2016.4
 reportlab==3.3.0
 zxcvbn-py3
+six

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -194,7 +194,7 @@ class MatchNotificationTest(MatchTest):
 class ReportDeliveryTest(MatchTest):
 
     def setUp(self):
-        super().setUp()
+        super(ReportDeliveryTest, self).setUp()
         self.user = self.user1
         self.decrypted_report = """[
     { "answer": "test answer",

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.core import mail
 
-from unittest.mock import patch, call
+from mock import patch, call
 from callisto.delivery.models import Report, MatchReport, EmailNotification
 from callisto.delivery.matching import find_matches
 from callisto.delivery.report_delivery import PDFFullReport, PDFMatchReport, SentFullReport, SentMatchReport

--- a/tests/callistocore/test_views.py
+++ b/tests/callistocore/test_views.py
@@ -40,7 +40,7 @@ class RecordFormBaseTest(TestCase):
 class RecordFormIntegratedTest(RecordFormBaseTest):
 
     def setUp(self):
-        super().setUp()
+        super(RecordFormIntegratedTest, self).setUp()
         User.objects.create_user(username='dummy', password='dummy')
         self.client.login(username='dummy', password='dummy')
         self.request = HttpRequest()
@@ -197,7 +197,7 @@ class EditRecordFormTest(RecordFormBaseTest):
     record_form_url = '/test_reports/edit/%s/'
 
     def setUp(self):
-        super().setUp()
+        super(EditRecordFormTest, self).setUp()
 
         User.objects.create_user(username='dummy', password='dummy')
         self.client.login(username='dummy', password='dummy')

--- a/tests/callistocore/test_views.py
+++ b/tests/callistocore/test_views.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest
-from unittest.mock import patch, Mock
+from mock import patch, Mock
 
 User = get_user_model()
 

--- a/tests/evaluation/tests.py
+++ b/tests/evaluation/tests.py
@@ -137,7 +137,7 @@ class ExtractAnswersTest(TestCase):
         EvaluationField.objects.create(question=radio_button_q, label="radio")
 
 
-        choice_ids = [choice.pk for choice in radio_button_q.choice_set.all()]
+        choice_ids = [ch.pk for ch in radio_button_q.choice_set.all()]
         selected_id = choice_ids[2]
 
         object_ids = [question1.pk, question2.pk, selected_id, radio_button_q.pk,] + choice_ids
@@ -214,7 +214,7 @@ class ExtractAnswersTest(TestCase):
                 choice.save()
         EvaluationField.objects.create(question=question3, label="q3")
 
-        q1_choice_ids = [choice.pk for choice in question1.choice_set.all()]
+        q1_choice_ids = [ch.pk for ch in question1.choice_set.all()]
         q1_selected_id = q1_choice_ids[1]
         first_q_object_ids = [q1_selected_id, question1.pk] + q1_choice_ids
         first_q_output = """{
@@ -230,7 +230,7 @@ class ExtractAnswersTest(TestCase):
           "section": 1
          }""" % tuple(first_q_object_ids)
 
-        q2_choice_ids = [choice.pk for choice in question2.choice_set.all()]
+        q2_choice_ids = [ch.pk for ch in question2.choice_set.all()]
         q2_selected_id = q2_choice_ids[3]
         second_q_object_ids = [q2_selected_id, question2.pk] + q2_choice_ids
         second_q_output = """{
@@ -250,7 +250,7 @@ class ExtractAnswersTest(TestCase):
                     }
          }""" % tuple(second_q_object_ids)
 
-        q3_choice_ids = [choice.pk for choice in question3.choice_set.all()]
+        q3_choice_ids = [ch.pk for ch in question3.choice_set.all()]
         q3_selected_id = q3_choice_ids[0]
         third_q_object_ids = [q3_selected_id, question3.pk] + q3_choice_ids
         third_q_output = """{
@@ -315,7 +315,7 @@ class ExtractAnswersTest(TestCase):
             Choice.objects.create(text="This is choice %i" % i, question = radio_button_q)
         EvaluationField.objects.create(question=radio_button_q, label="radio")
 
-        choice_ids = [choice.pk for choice in radio_button_q.choice_set.all()]
+        choice_ids = [ch.pk for ch in radio_button_q.choice_set.all()]
         selected_id_1 = choice_ids[1]
         selected_id_2 = choice_ids[4]
         object_ids = [question1.pk, question2.pk, radio_button_q.pk,] + choice_ids
@@ -402,7 +402,7 @@ class ExtractAnswersTest(TestCase):
         for i in range(5):
             Choice.objects.create(text="This is choice %i" % i, question = radio_button_q)
 
-        choice_ids = [choice.pk for choice in radio_button_q.choice_set.all()]
+        choice_ids = [ch.pk for ch in radio_button_q.choice_set.all()]
         object_ids = [question1.pk, question2.pk, radio_button_q.pk,] + choice_ids
 
         json_report = json.loads("""[
@@ -450,8 +450,8 @@ class ExtractAnswersTest(TestCase):
         for i in range(5):
             Choice.objects.create(text="This is choice %i" % i, question = checkbox_q_2)
 
-        choice_ids_1 = [choice.pk for choice in checkbox_q_1.choice_set.all()]
-        choice_ids_2 = [choice.pk for choice in checkbox_q_2.choice_set.all()]
+        choice_ids_1 = [ch.pk for ch in checkbox_q_1.choice_set.all()]
+        choice_ids_2 = [ch.pk for ch in checkbox_q_2.choice_set.all()]
         object_ids = [checkbox_q_1.pk] + choice_ids_1 + [choice_ids_2[1], choice_ids_2[3], checkbox_q_2.pk]+ choice_ids_2
 
         json_report = json.loads("""[

--- a/tests/evaluation/tests.py
+++ b/tests/evaluation/tests.py
@@ -1,6 +1,7 @@
 import json
 
 import gnupg
+import six
 from callisto.delivery.models import Report
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
@@ -94,7 +95,7 @@ class EvalRowTest(TestCase):
         row._encrypt_eval_row(test_row, key = public_test_key)
         row.save()
         row.full_clean()
-        self.assertEqual(str(gpg.decrypt(EvalRow.objects.get(id=row.pk).row)), test_row)
+        self.assertEqual(six.text_type(gpg.decrypt(six.binary_type(EvalRow.objects.get(id=row.pk).row))), test_row)
 
 class EvalFieldTest(TestCase):
 
@@ -504,4 +505,4 @@ class ExtractAnswersTest(TestCase):
                              key = public_test_key)
         row.save()
 
-        self.assertEqual(json.loads(str(gpg.decrypt(EvalRow.objects.get(id=row.pk).row))), self.expected)
+        self.assertEqual(json.loads(six.text_type(gpg.decrypt(six.binary_type(EvalRow.objects.get(id=row.pk).row)))), self.expected)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,11 +7,11 @@ USE_TZ = True
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': os.environ.get('db_name', default='callisto'),
-        'USER': os.environ.get('db_user', default=''),
-        'PASSWORD': os.environ.get('db_pass', default=''),
-        'HOST': os.environ.get('db_host', default='127.0.0.1'),
-        'PORT': os.environ.get('db_port', default='5432')
+        'NAME': os.environ.get('db_name', 'callisto'),
+        'USER': os.environ.get('db_user', ''),
+        'PASSWORD': os.environ.get('db_pass', ''),
+        'HOST': os.environ.get('db_host', '127.0.0.1'),
+        'PORT': os.environ.get('db_port', '5432')
     }
 }
 


### PR DESCRIPTION
This is for #23. For starters, here's the .travis.yml syntax to skip the Python 3.3/Django 1.9 combination.