### PR TITLE
Add codecov to Travis CI configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+source = callisto

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,11 @@ matrix:
         - python: "3.3"
           env: TOXENV=django19
 install:
-    - pip install pyflakes tox
+    - pip install pyflakes tox codecov
 script:
     - pyflakes setup.py runtests.py tests callisto
     - tox
+after_success:
+    - codecov -e TOXENV
 before_cache:
     - rm -r $TRAVIS_BUILD_DIR/.tox/log $TRAVIS_BUILD_DIR/.tox/dist $TRAVIS_BUILD_DIR/.tox/*/log $TRAVIS_BUILD_DIR/.tox/*/lib/python*/site-packages/callisto*

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
 [testenv]
 passenv = db_name db_user db_pass db_host db_port
 setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/delivery
-commands = python runtests.py
+    PYTHONPATH = {toxinidir}
+commands = coverage run runtests.py
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
As discussed in #22. This collects coverage data during tests, and uploads it from Travis CI to codecov.io.