### PR TITLE
Add isort instructions to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,13 @@ We're working on moving relevant issues from our private bug tracker over to the
 #### Your first contribution
 Working on your first open source contribution? We are so excited to have you! You can learn how to make a pull request from this free series [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)!
 
+#### Coding style
+
+We are adhering to [Django's coding style guide](https://docs.djangoproject.com/en/1.9/internals/contributing/writing-code/coding-style/), including a maximum line length of 119 characters. You'll find relevant configuration in [`setup.cfg`](https://github.com/SexualHealthInnovations/callisto-core/blob/master/setup.cfg). 
+
+As Django's style guide explains, you can use `isort` to automatically sort imports. Install `isort` into your virtual environment with `pip install isort`. If you want to sort imports throughout the entire project, run `isort -rc .` in the root directory of the project. To sort a single file: `isort <path/to/file>`. In order to comply with Django's preferred order for imports, after running isort you'll need to move imports from django up so they come after third-party imports (e.g. `from zxcvbn import password_strength`) and before local django imports (e.g. `from .models import EvaluationField`). 
+
+
 #### How to submit
 We need all contributors to sign our [volunteer agreement](https://github.com/SexualHealthInnovations/callisto-core/blob/master/shi-volunteer-agreement.pdf) (PDF) in order to accept contributions. Signed agreements can be submitted to tech@sexualhealthinnovations.org. We can take fixes to documentation without a signed agreement.
 


### PR DESCRIPTION
Close #57.

Add instructions for using `isort` to the contributor's guide, per
https://github.com/SexualHealthInnovations/callisto-core/pull/41#issuecomment-229228535. I added it above the "how to submit" section, so it should be easy to merge with #38. 

By the way, is there a reason we jump from a first-level heading to fourth-level headings in `CONTRIBUTING.md`? 