### PR TITLE
WIP Add custom time zones to delivered report

### DIFF
--- a/callisto/delivery/report_delivery.py
+++ b/callisto/delivery/report_delivery.py
@@ -25,10 +25,7 @@ from .models import EmailNotification, SentFullReport, SentMatchReport
 
 date_format = "%m/%d/%Y @%H:%M%p"
 # TODO: customize https://github.com/SexualHealthInnovations/callisto-core/issues/20
-if settings.TIME_ZONE is None:
-    tzname = 'America/Los_Angeles'
-else:
-    tzname = settings.TIME_ZONE
+tzname = settings.TIME_ZONE or 'America/Los_Angeles'
 timezone.activate(pytz.timezone(tzname))
 logger = logging.getLogger(__name__)
 

--- a/callisto/delivery/report_delivery.py
+++ b/callisto/delivery/report_delivery.py
@@ -25,7 +25,10 @@ from .models import EmailNotification, SentFullReport, SentMatchReport
 
 date_format = "%m/%d/%Y @%H:%M%p"
 # TODO: customize https://github.com/SexualHealthInnovations/callisto-core/issues/20
-tzname = 'America/Los_Angeles'
+if settings.TIME_ZONE is None:
+    tzname = 'America/Los_Angeles'
+else:
+    tzname = settings.TIME_ZONE
 timezone.activate(pytz.timezone(tzname))
 logger = logging.getLogger(__name__)
 

--- a/callisto/delivery/report_delivery.py
+++ b/callisto/delivery/report_delivery.py
@@ -24,8 +24,7 @@ from django.utils.timezone import localtime
 from .models import EmailNotification, SentFullReport, SentMatchReport
 
 date_format = "%m/%d/%Y @%H:%M%p"
-# TODO: customize https://github.com/SexualHealthInnovations/callisto-core/issues/20
-tzname = settings.TIME_ZONE or 'America/Los_Angeles'
+tzname = settings.TIME_ZONE
 timezone.activate(pytz.timezone(tzname))
 logger = logging.getLogger(__name__)
 

--- a/callisto/delivery/report_delivery.py
+++ b/callisto/delivery/report_delivery.py
@@ -24,7 +24,7 @@ from django.utils.timezone import localtime
 from .models import EmailNotification, SentFullReport, SentMatchReport
 
 date_format = "%m/%d/%Y @%H:%M%p"
-tzname = settings.TIME_ZONE
+tzname = settings.REPORT_TIME_ZONE
 timezone.activate(pytz.timezone(tzname))
 logger = logging.getLogger(__name__)
 

--- a/callisto/delivery/report_delivery.py
+++ b/callisto/delivery/report_delivery.py
@@ -24,7 +24,7 @@ from django.utils.timezone import localtime
 from .models import EmailNotification, SentFullReport, SentMatchReport
 
 date_format = "%m/%d/%Y @%H:%M%p"
-tzname = settings.REPORT_TIME_ZONE
+tzname = settings.REPORT_TIME_ZONE or 'America/Los_Angeles'
 timezone.activate(pytz.timezone(tzname))
 logger = logging.getLogger(__name__)
 

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -52,16 +52,16 @@ class ReportDeliveryTest(MatchTest):
         self.assertIn("answer to 2nd question", pdfReader.getPage(1).extractText())
 
     def test_pdf_report_generated_with_timestamp(self):
-        tzname = 'Europe/Paris'
-        timezone.activate(pytz.timezone(tzname))
+        # test_tzname matches TIME_ZONE in tests/settings.py
+        test_tzname = 'Europe/Paris'
         report = PDFFullReport(self.report, self.decrypted_report)
         output = report.generate_pdf_report(recipient=None, report_id=None)
         exported_report = BytesIO(output)
         pdfReader = PyPDF2.PdfFileReader(exported_report)
-        timezone.deactivate()
         date_format = "%m/%d/%Y @%H:%M%p"
-        timezone.activate(pytz.timezone(tzname))
+        timezone.activate(pytz.timezone(test_tzname))
         expected_time = localtime(timezone.now()).strftime(date_format)
+        print(pdfReader.getPage(0).extractText())
         self.assertIn(expected_time, pdfReader.getPage(0).extractText())
 
     def test_submission_to_school(self):

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -48,6 +48,14 @@ class ReportDeliveryTest(MatchTest):
         self.assertIn("test answer", pdfReader.getPage(1).extractText())
         self.assertIn("answer to 2nd question", pdfReader.getPage(1).extractText())
 
+    def test_pdf_report_generated_with_timestamp(self):
+        @override_settings(TIME_ZONE="Europe/Paris")
+        report = PDFFullReport(self.report, self.decrypted_report)
+        output = report.generate_pdf_report(recipient=None, report_id=None)
+        exported_report = BytesIO(output)
+        pdfReader = PyPDF2.PdfFileReader(exported_report)
+        self.assertIn("")
+
     def test_submission_to_school(self):
         EmailNotification.objects.create(name='report_delivery', subject="test delivery", body="test body")
         report = PDFFullReport(self.report, self.decrypted_report)

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -4,6 +4,7 @@ import PyPDF2
 
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.test.utils import override_settings
 
 from callisto.delivery.models import EmailNotification, Report
 from callisto.delivery.report_delivery import (
@@ -48,8 +49,8 @@ class ReportDeliveryTest(MatchTest):
         self.assertIn("test answer", pdfReader.getPage(1).extractText())
         self.assertIn("answer to 2nd question", pdfReader.getPage(1).extractText())
 
+    @override_settings(TIME_ZONE="Europe/Paris")
     def test_pdf_report_generated_with_timestamp(self):
-        @override_settings(TIME_ZONE="Europe/Paris")
         report = PDFFullReport(self.report, self.decrypted_report)
         output = report.generate_pdf_report(recipient=None, report_id=None)
         exported_report = BytesIO(output)

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -5,7 +5,6 @@ import pytz
 
 from django.contrib.auth import get_user_model
 from django.core import mail
-from django.test.utils import override_settings
 from django.utils import timezone
 from django.utils.timezone import localtime
 

--- a/tests/callistocore/test_delivery.py
+++ b/tests/callistocore/test_delivery.py
@@ -61,7 +61,6 @@ class ReportDeliveryTest(MatchTest):
         date_format = "%m/%d/%Y @%H:%M%p"
         timezone.activate(pytz.timezone(test_tzname))
         expected_time = localtime(timezone.now()).strftime(date_format)
-        print(pdfReader.getPage(0).extractText())
         self.assertIn(expected_time, pdfReader.getPage(0).extractText())
 
     def test_submission_to_school(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,7 +3,7 @@ import os
 DEBUG = True
 
 USE_TZ = True
-TIME_ZONE = 'Europe/Paris'
+REPORT_TIME_ZONE = 'Europe/Paris'
 
 DATABASES = {
     "default": {

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,6 +3,7 @@ import os
 DEBUG = True
 
 USE_TZ = True
+TIME_ZONE = 'Europe/Paris'
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
Here's what I have for #20 so far. I kept PDT set as a default time zone if there's none specified in the settings. Is that alright? 
I'm not certain what I want to be asserting in the test. Is there any way to view a sample delivered report pdf to see what its contents look like (since it looks like we're asserting that it contains a specified string)?