### PR TITLE
Added namespace to docs import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 import os
 import sys
 
-import delivery
+from callisto import delivery
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
Closes #95 (docs now build without error, and `callisto.delivery` methods appear in docs).