### PR TITLE
Remove Python 3.2 from tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py32,py33,py34,py35}-django18
+    {py27,py33,py34,py35}-django18
     {py27,py34,py35}-django19
 
 [testenv]


### PR DESCRIPTION
Python 3.2 is already out of the Travis CI config, and "reportlab requires Python 2.7+ or 3.3+; 3.0-3.2 are not supported." This PR removes Python 3.2 from tox.ini to fix local testing.