### PR TITLE
Django 1.10 tracking PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ cache:
 env:
     - TOXENV=django18
     - TOXENV=django19
+    - TOXENV=django110
 matrix:
     exclude:
         - python: "3.3"
           env: TOXENV=django19
+        - python: "3.3"
+          env: TOXENV=django110
 install:
     - pip install tox codecov isort flake8
 before_script:

--- a/tox.ini.in
+++ b/tox.ini.in
@@ -2,6 +2,7 @@
 envlist =
     {py27,py33,py34,py35}-django18,
     {py27,py34,py35}-django19
+    {py27,py34,py35}-django110
 
 [testenv]
 passenv = db_name db_user db_pass db_host db_port
@@ -11,4 +12,5 @@ commands = coverage run runtests.py
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     -rrequirements-test.txt


### PR DESCRIPTION
Adds django 1.10 to tox settings, allows us to watch the travis build until django-polymathic releases its new version that works with django 1.10.

Note to self: pin django-polymathic to new version before merging if that's preferred