### PR TITLE
Make callisto-core pip installable

### DIFF
--- a/register.py
+++ b/register.py
@@ -1,0 +1,13 @@
+# example taken from
+# https://coderwall.com/p/qawuyq/use-markdown-readme-s-in-python-modules
+
+import os
+import pandoc
+
+doc = pandoc.Document()
+doc.markdown = open('README.md').read()
+f = open('README.txt', 'w+')
+f.write(doc.rst)
+f.close()
+os.system('python setup.py register')
+os.remove('README.txt')

--- a/setup.py
+++ b/setup.py
@@ -42,16 +42,19 @@ if sys.argv[-1] == 'tag':
 
 readme = open('README.md').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+license = open('LICENSE').read()
 
 setup(
     name='callisto-core',
     version=__version__,
     description="""Report intake, escrow, matching and secure delivery code for Callisto,
     an online reporting system for sexual assault.""",
+    license=license,
     long_description=readme + '\n\n' + history,
     author='Sexual Health Innovations',
     author_email='tech@sexualhealthinnovations.org',
     url='https://github.com/SexualHealthInnovations/callisto-core',
+    download_url='https://github.com/SexualHealthInnovations/callisto-core/tarball/release-8.15.16-2/',
     packages=[
         'callisto.delivery',
         'callisto.evaluation'],


### PR DESCRIPTION
Manually installing dependencies is no fun, fully pip installable
packages are easier to develop with. This change updates metadata in
`setup.py` so that the package can be registered with pip.

Pip deployment:

- Register with pypi and setup your
  [~/.pypirc](https://docs.python.org/2/distutils/packageindex.html#the-pypirc-file)
- `python register.py`
- `python setup.py sdist upload -r pypi`

Future releases will need to update the `download_url` field in
`setup.py`

Fixes #101