### PR TITLE
Add request.domain support to email notification

### DIFF
--- a/callisto/delivery/api.py
+++ b/callisto/delivery/api.py
@@ -61,6 +61,10 @@ class AbstractNotification:
     def send_email_to_coordinator(self):
         pass
 
+    @abstractmethod
+    def get_user_site(self):
+        pass
+
     # TODO: https://github.com/SexualHealthInnovations/callisto-core/issues/150
     # TODO (cont): create AbstractPDFGenerator class
     @abstractmethod

--- a/callisto/delivery/views.py
+++ b/callisto/delivery/views.py
@@ -44,8 +44,8 @@ def check_owner(action_name, report_id_arg='report_id'):
                     logger.warning("illegal {} attempt on record {} by user {}".format(action_name,
                                                                                        id_to_fetch, owner.id))
                     return HttpResponseForbidden() if settings.DEBUG else HttpResponseNotFound()
-            except ObjectDoesNotExist:
-                logger.warn('failed check_owner')
+            except Report.DoesNotExist:
+                logger.info('Get request for nonexistant report Report(id={})'.format(id_to_fetch))
                 return HttpResponseNotFound()
         return _wrapped_view
     return decorator

--- a/callisto/delivery/views.py
+++ b/callisto/delivery/views.py
@@ -8,7 +8,6 @@ from wizard_builder.models import PageBase
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.exceptions import ObjectDoesNotExist
 from django.http import (
     HttpResponse, HttpResponseForbidden, HttpResponseNotFound,
     HttpResponseServerError,

--- a/callisto/delivery/views.py
+++ b/callisto/delivery/views.py
@@ -45,7 +45,7 @@ def check_owner(action_name, report_id_arg='report_id'):
                                                                                        id_to_fetch, owner.id))
                     return HttpResponseForbidden() if settings.DEBUG else HttpResponseNotFound()
             except Report.DoesNotExist:
-                logger.info('Get request for nonexistant report Report(id={})'.format(id_to_fetch))
+                logger.info('Got request for nonexistant report Report(id={})'.format(id_to_fetch))
                 return HttpResponseNotFound()
         return _wrapped_view
     return decorator

--- a/callisto/delivery/views.py
+++ b/callisto/delivery/views.py
@@ -45,6 +45,7 @@ def check_owner(action_name, report_id_arg='report_id'):
                                                                                        id_to_fetch, owner.id))
                     return HttpResponseForbidden() if settings.DEBUG else HttpResponseNotFound()
             except ObjectDoesNotExist:
+                logger.warn('failed check_owner')
                 return HttpResponseNotFound()
         return _wrapped_view
     return decorator

--- a/callisto/notification/api.py
+++ b/callisto/notification/api.py
@@ -23,6 +23,12 @@ class NotificationApi(AbstractNotification):
     report_filename = "report_{0}.pdf.gpg"
     from_email = '"Reports" <reports@{0}>'.format(settings.APP_URL)
 
+    @classmethod
+    def get_user_site(self, user):
+        '''Takes in a user model, and should return a site_id
+        '''
+        return None
+
     # TODO: https://github.com/SexualHealthInnovations/callisto-core/issues/150
     # TODO (cont): remove this method, make it a attribute
     @classmethod
@@ -73,7 +79,8 @@ class NotificationApi(AbstractNotification):
           user(User): reporting user
           match_report(MatchReport): MatchReport for which a match has been found
         """
-        notification = cls.model.objects.on_site().get(name='match_notification')
+        site_id = cls.get_user_site(user)
+        notification = cls.model.objects.on_site(site_id).get(name='match_notification')
         from_email = '"Callisto Matching" <notification@{0}>'.format(settings.APP_URL)
         to = match_report.contact_email
         context = {'report': match_report.report}

--- a/callisto/notification/api.py
+++ b/callisto/notification/api.py
@@ -34,13 +34,13 @@ class NotificationApi(AbstractNotification):
         return []
 
     @classmethod
-    def send_report_to_school(cls, sent_full_report, decrypted_report):
+    def send_report_to_school(cls, sent_full_report, decrypted_report, site_id=None):
         logger.info("sending report to reporting authority")
         pdf_report_id = sent_full_report.get_report_id()
         sent_full_report.report.submitted_to_school = timezone.now()
         # TODO: https://github.com/SexualHealthInnovations/callisto-core/issues/150
         pdf = PDFFullReport(sent_full_report.report, decrypted_report).generate_pdf_report(pdf_report_id)
-        cls.send_email_to_coordinator(pdf, 'report_delivery', pdf_report_id)
+        cls.send_email_to_coordinator(pdf, 'report_delivery', pdf_report_id, site_id)
         # save report timestamp only if generation & email work
         sent_full_report.report.save()
 
@@ -57,8 +57,8 @@ class NotificationApi(AbstractNotification):
         cls.send_email_to_coordinator(pdf, 'match_delivery', report_id)
 
     @classmethod
-    def send_user_notification(cls, form, notification_name):
-        notification = cls.model.objects.on_site().get(name=notification_name)
+    def send_user_notification(cls, form, notification_name, site_id=None):
+        notification = cls.model.objects.on_site(site_id).get(name=notification_name)
         preferred_email = form.cleaned_data.get('email')
         to_email = preferred_email
         from_email = '"Callisto Confirmation" <confirmation@{0}>'.format(settings.APP_URL)
@@ -80,8 +80,8 @@ class NotificationApi(AbstractNotification):
         notification.send(to=[to], from_email=from_email, context=context)
 
     @classmethod
-    def send_email_to_coordinator(cls, pdf_to_attach, notification_name, report_id):
-        notification = cls.model.objects.on_site().get(name=notification_name)
+    def send_email_to_coordinator(cls, pdf_to_attach, notification_name, report_id, site_id=None):
+        notification = cls.model.objects.on_site(site_id).get(name=notification_name)
 
         to_addresses = [x.strip() for x in settings.COORDINATOR_EMAIL.split(',')]
 

--- a/callisto/notification/api.py
+++ b/callisto/notification/api.py
@@ -26,6 +26,10 @@ class NotificationApi(AbstractNotification):
     @classmethod
     def get_user_site(self, user):
         '''Takes in a user model, and should return a site_id
+
+        example:
+            for an Account model 1 to 1 with User that has a site attribute
+            return user.account.site.id
         '''
         return None
 

--- a/callisto/notification/models.py
+++ b/callisto/notification/models.py
@@ -54,7 +54,7 @@ class EmailNotification(models.Model):
         email.send()
 
     def add_site_from_site_id(self):
-        if getattr(settings, 'SITE_ID'):
+        if getattr(settings, 'SITE_ID', None):
             self.sites.add(settings.SITE_ID)
 
     def save(self, *args, **kwargs):

--- a/tests/notification/test_sites.py
+++ b/tests/notification/test_sites.py
@@ -72,14 +72,18 @@ class SiteRequestTest(TestCase):
         self.submit_url = reverse('test_submit_report', args=[self.report.pk])
 
     @override_settings()
-    def test_can_request_pages_without_site_id_set(self):
+    @patch('django.http.request.HttpRequest.get_host')
+    def test_can_request_pages_without_site_id_set(self, mock_get_host):
+        mock_get_host.return_value = Site.objects.get(id=settings.SITE_ID).domain
         del settings.SITE_ID
         response = self.client.get(self.submit_url)
         self.assertNotEqual(response.status_code, 404)
 
     @override_settings()
+    @patch('django.http.request.HttpRequest.get_host')
     @patch('callisto.notification.managers.EmailNotificationQuerySet.on_site')
-    def test_site_passed_to_email_notification_manager(self, mock_on_site):
+    def test_site_passed_to_email_notification_manager(self, mock_on_site, mock_get_host):
+        mock_get_host.return_value = Site.objects.get(id=settings.SITE_ID).domain
         site_id = settings.SITE_ID
         del settings.SITE_ID
         self.client.post(

--- a/tests/notification/test_sites.py
+++ b/tests/notification/test_sites.py
@@ -3,8 +3,8 @@ from mock import patch
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
-from django.urls import reverse
 
 from callisto.delivery.models import Report
 from callisto.notification.models import EmailNotification


### PR DESCRIPTION
WIP tracking PR

closes #148 

The current state of affairs is that 30% of the tests fail when I remove `SITE_ID`, and I have no idea why