### PR TITLE
EmailNotification admin updates

### DIFF
--- a/callisto/notification/models.py
+++ b/callisto/notification/models.py
@@ -64,8 +64,7 @@ class EmailNotification(models.Model):
         email.send()
 
     def add_site_from_site_id(self):
-        if not self.sites.count() \
-        and getattr(settings, 'SITE_ID', None):
+        if not self.sites.count() and getattr(settings, 'SITE_ID', None):
             # django does better validation checks for ints
             site_id = int(settings.SITE_ID)
             self.sites.add(site_id)

--- a/callisto/notification/models.py
+++ b/callisto/notification/models.py
@@ -64,7 +64,8 @@ class EmailNotification(models.Model):
         email.send()
 
     def add_site_from_site_id(self):
-        if getattr(settings, 'SITE_ID', None):
+        if not self.sites.count() \
+        and getattr(settings, 'SITE_ID', None):
             # django does better validation checks for ints
             site_id = int(settings.SITE_ID)
             self.sites.add(site_id)

--- a/callisto/notification/validators.py
+++ b/callisto/notification/validators.py
@@ -10,5 +10,5 @@ def validate_email_unique(email):
             email.sites.remove(site.id)
     if invalid_sites:
         raise ValidationError('''
-                EmailNotification already exists with (name={} ,sites__domain__in=[{}])
+                EmailNotification already exists with (name={}, sites__domain__in=[{}])
             '''.format(email.name, invalid_sites))

--- a/callisto/notification/validators.py
+++ b/callisto/notification/validators.py
@@ -7,5 +7,5 @@ def validate_email_unique(email):
         if EmailNotification.objects.filter(name=email.name, sites__id__in=[site.id]).exclude(id=email.id):
             email.sites.remove(site.id)
             raise ValidationError('''
-                    EmailNotification already existed with (name={} ,site__domain={})
+                    EmailNotification already exists with (name={} ,site__domain={})
                 '''.format(email.name, site.domain))

--- a/callisto/notification/validators.py
+++ b/callisto/notification/validators.py
@@ -3,9 +3,12 @@ from django.core.exceptions import ValidationError
 
 def validate_email_unique(email):
     EmailNotification = email.__class__
+    invalid_sites = []
     for site in email.sites.all():
         if EmailNotification.objects.filter(name=email.name, sites__id__in=[site.id]).exclude(id=email.id):
+            invalid_sites.append(site.domain)
             email.sites.remove(site.id)
-            raise ValidationError('''
-                    EmailNotification already exists with (name={} ,site__domain={})
-                '''.format(email.name, site.domain))
+    if invalid_sites:
+        raise ValidationError('''
+                EmailNotification already exists with (name={} ,sites__domain__in=[{}])
+            '''.format(email.name, invalid_sites))

--- a/callisto/notification/validators.py
+++ b/callisto/notification/validators.py
@@ -5,7 +5,7 @@ def validate_email_unique(email):
     EmailNotification = email.__class__
     for site in email.sites.all():
         if EmailNotification.objects.filter(name=email.name, sites__id__in=[site.id]).exclude(id=email.id):
-            email.delete()
+            email.sites.remove(site.id)
             raise ValidationError('''
-                    EmailNotification already exists with (name={} ,site__domain={})
+                    EmailNotification already existed with (name={} ,site__domain={})
                 '''.format(email.name, site.domain))

--- a/tests/notification/test_validation.py
+++ b/tests/notification/test_validation.py
@@ -84,6 +84,20 @@ class EmailValidationTest(TestCase):
             email.full_clean()
         self.assertEqual(EmailNotification.objects.on_site(2).count(), 1)
 
+    def test_validation_error_contains_identifying_information(self):
+        email_name = 'example email'
+        invalid_site = 2
+        with self.assertRaises(ValidationError) as error_context:
+            email = EmailNotification.objects.get(
+                name=email_name,
+                sites__id__in=[1],
+            )
+            email.sites.add(invalid_site)
+            email.full_clean()
+        exception_text = str(error_context.exception)
+        self.assertIn(email_name, exception_text)
+        self.assertIn(str(invalid_site), exception_text)
+
     def test_all_duplicate_sites_removed(self):
         with self.assertRaises(ValidationError):
             email_with_invalid_sites = EmailNotification.objects.get(

--- a/tests/notification/test_validation.py
+++ b/tests/notification/test_validation.py
@@ -18,6 +18,26 @@ class EmailValidationTest(TestCase):
             site.save()
 
     @override_settings()
+    def test_validation_error_does_not_delete_email(self):
+        del settings.SITE_ID
+        for i in range(1, 10):
+            email = EmailNotification.objects.create(
+                name='example email',
+                body='example email',
+                subject='example email',
+            )
+            email.sites.add(i)
+            email.full_clean()
+        with self.assertRaises(ValidationError):
+            invalid_email = EmailNotification.objects.get(
+                name='example email',
+                sites__id__in=[1],
+            )
+            invalid_email.sites.add(2)
+            invalid_email.full_clean()
+        self.assertTrue(invalid_email.pk)
+
+    @override_settings()
     def test_duplicate_emails_not_allowed_on_same_site(self):
         del settings.SITE_ID
         site_id = 1


### PR DESCRIPTION
- only add the SITE_ID when one is not already set (allows for easier editing of emails from the site you are not currently logged into)
- remove the current site when getting validation errors, instead of deleting it (which I thought wouldn't be an issue, but it turns out that its incredibly disruptive on admin)
- remove *all* invalid sites when invalid sites are found
- add test to ensure the email notification validation error includes enough information to resolve the error