### PR TITLE
Catch error when pandoc is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ try:
     import pypandoc
     readme = pypandoc.convert_file('README.md', 'rst')
     print("Converting README from markdown to restructured text")
-except (IOError, ImportError):
+except (IOError, ImportError, OSError):
     print("Please install PyPandoc to allow conversion of the README")
     readme = open('README.md').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')


### PR DESCRIPTION
When I ran setup.py without pandoc installed, I got an OSError, not an IOError, because of the missing program. This PR updates the `except` clause to handle the error.